### PR TITLE
Update RegexpTokenizer.php

### DIFF
--- a/src/Tokenizer/RegexpTokenizer.php
+++ b/src/Tokenizer/RegexpTokenizer.php
@@ -13,6 +13,6 @@ class RegexpTokenizer implements TokenizerInterface
 
     public function tokenize($text)
     {
-        return preg_split($this->regexp, $text, null, PREG_SPLIT_NO_EMPTY);
+        return preg_split($this->regexp, $text, -1, PREG_SPLIT_NO_EMPTY);
     }
 }


### PR DESCRIPTION
Remove deprecation's notices of null since PHP 7.4  see docs   limit should be 0 or -1 for unlimited https://www.php.net/manual/en/function.preg-split.php